### PR TITLE
Ember 1.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ using [Ember CLI](http://www.ember-cli.com/).
 
 The application includes:
 
-✓ Ember [v1.10](http://emberjs.com/blog/2015/02/07/ember-1-10-0-released.html)  
-✓ HTMLBars [templates](https://github.com/amercier/todomvc-ember-cli/tree/master/app/templates)  
+✓ Ember [v1.11](http://emberjs.com/blog/2015/03/27/ember-1-11-0-released.html)  
+✓ HTMLBars [templates](https://github.com/amercier/todomvc-ember-cli/tree/master/app/templates) with new bound attribute syntax  
 ✗ (not implemented yet) Ember components  
 ✓ Unit and end-to-end tests using [QUnit](http://qunitjs.com/) and [Testem](https://github.com/airportyh/testem)  
 ✓ Continuous Integration setup with [Travis CI](https://travis-ci.org/)  

--- a/app/controllers/todo.js
+++ b/app/controllers/todo.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-export default Ember.ObjectController.extend({
+export default Ember.Controller.extend({
   actions: {
     editTodo: function() {
       this.set('isEditing', true);

--- a/app/templates/todos/index.hbs
+++ b/app/templates/todos/index.hbs
@@ -3,14 +3,14 @@
     <li class="{{if todo.isCompleted 'completed'}} {{if todo.isEditing 'editing'}}">
       {{#if todo.isEditing}}
         {{input class="edit"
-                value=todo.title
+                value=todo.model.title
                 focus-out="acceptChanges"
                 insert-newline="acceptChanges"
                 autofocus="autofocus"
         }}
       {{else}}
         {{input type="checkbox" checked=todo.isCompleted class="toggle"}}
-        <label {{action "editTodo" on="doubleClick"}}>{{todo.title}}</label>
+        <label {{action "editTodo" on="doubleClick"}}>{{todo.model.title}}</label>
         <button {{action "removeTodo"}} class="destroy"></button>
       {{/if}}
     </li>

--- a/app/templates/todos/index.hbs
+++ b/app/templates/todos/index.hbs
@@ -1,6 +1,6 @@
 <ul id="todo-list">
   {{#each todo in this itemController="todo"}}
-    <li {{bind-attr class="todo.isCompleted:completed todo.isEditing:editing"}}>
+    <li class="{{if todo.isCompleted 'completed'}} {{if todo.isEditing 'editing'}}">
       {{#if todo.isEditing}}
         {{input class="edit"
                 value=todo.title

--- a/bower.json
+++ b/bower.json
@@ -1,17 +1,17 @@
 {
   "name": "todomvc-ember-cli",
   "dependencies": {
-    "ember": "1.10.0",
+    "ember": "1.11.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "ember-cli/ember-cli-test-loader#0.1.0",
-    "ember-data": "1.0.0-beta.15",
+    "ember-cli-test-loader": "0.1.3",
+    "ember-data": "1.0.0-beta.16.1",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
-    "ember-localstorage-adapter": "0.5.1",
-    "ember-qunit": "rwjblue/ember-qunit-builds#0.2.1",
+    "ember-localstorage-adapter": "0.5.2",
+    "ember-qunit": "0.3.0",
     "ember-qunit-notifications": "0.0.7",
-    "ember-resolver": "0.1.11",
+    "ember-resolver": "0.1.15",
     "jquery": "2.1.3",
-    "loader.js": "3.1.0",
+    "loader.js": "3.2.1",
     "qunit": "1.17.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,22 +10,22 @@
     "install": "bower install"
   },
   "devDependencies": {
-    "body-parser": "1.10.1",
+    "body-parser": "1.12.2",
     "bower": "1.3.12",
-    "broccoli-asset-rev": "2.0.1",
-    "broccoli-clean-css": "^1.0.0",
-    "ember-cli": "0.1.12",
-    "ember-cli-app-version": "^0.3.1",
-    "ember-cli-content-security-policy": "0.3.0",
-    "ember-cli-htmlbars": "0.6.0",
+    "broccoli-asset-rev": "2.0.3",
+    "broccoli-clean-css": "1.0.0",
+    "ember-cli": "0.2.1",
+    "ember-cli-app-version": "0.3.3",
+    "ember-cli-content-security-policy": "0.4.0",
+    "ember-cli-htmlbars": "0.7.4",
     "ember-cli-ic-ajax": "0.1.1",
-    "ember-cli-inject-live-reload": "1.3.0",
-    "ember-cli-qunit": "0.3.4",
-    "ember-cli-uglify": "^1.0.1",
-    "ember-data": "1.0.0-beta.14.1",
-    "ember-export-application-global": "1.0.1",
-    "express": "4.11.2",
-    "glob": "4.3.5",
-    "phantomjs": "1.9.15"
+    "ember-cli-inject-live-reload": "1.3.1",
+    "ember-cli-qunit": "0.3.9",
+    "ember-cli-uglify": "1.0.1",
+    "ember-data": "1.0.0-beta.16.1",
+    "ember-export-application-global": "1.0.2",
+    "express": "4.12.3",
+    "glob": "5.0.3",
+    "phantomjs": "1.9.16"
   }
 }

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -27,7 +27,8 @@ export default function startApp(attrs) {
     });
   });
 
-  App.reset(); // this shouldn't be needed, i want to be able to "start an app at a specific URL"
+  // Disabled due to https://github.com/emberjs/ember.js/issues/10310
+  // App.reset(); // this shouldn't be needed, i want to be able to "start an app at a specific URL"
 
   return App;
 }


### PR DESCRIPTION
Following release of [Ember v1.11.0](http://emberjs.com/blog/2015/03/27/ember-1-11-0-released.html):

- [x] Upgrade NPM dependencies
- [x] Upgrade Ember to v1.11.0
- [x] Update templates with new bound attributes syntax
- [x] Fix test errors:
  - [x] beforeEach failed on Application fixtures are initialized: Cannot re-register: `store:main`, as it has already been resolved.
- [ ] Update deprecated code
  - [x] Ember.ObjectController is deprecated, please use Ember.Controller and use `model.propertyName`.
  - [x] You attempted to access `title` from `<todomvc-ember-cli@controller:todo::ember479>`, but object proxying is deprecated. Please use `model.title` instead.
  - [ ] Usage of `snapshot.constructor` is deprecated, use `snapshot.type` instead
  - [ ] Using DS.Snapshot.get() is deprecated. Use .attr(), .belongsTo() or .hasMany() instead.
  - [ ] You called _createSnapshot on what's already a DS.Snapshot. You shouldn't manually create snapshots in your adapter since the store passes snapshots to adapters by default.
- [x] Update documentation