### PR TITLE
Ember 1.12

### DIFF
--- a/app/controllers/todo.js
+++ b/app/controllers/todo.js
@@ -23,17 +23,15 @@ export default Ember.Controller.extend({
 
   isEditing: false,
 
-  isCompleted: function(key, value){
-    var model = this.get('model');
-
-    if (value === undefined) {
-      // property being used as a getter
-      return model.get('isCompleted');
-    } else {
-      // property being used as a setter
+  isCompleted: Ember.computed('model.isCompleted', {
+    get: function() {
+      return this.get('model').get('isCompleted');
+    },
+    set: function(key, value) {
+      var model = this.get('model');
       model.set('isCompleted', value);
       model.save();
       return value;
     }
-  }.property('model.isCompleted')
+  })
 });

--- a/app/controllers/todos.js
+++ b/app/controllers/todos.js
@@ -44,14 +44,15 @@ export default Ember.ArrayController.extend({
     return this.filterBy('isCompleted', true).get('length');
   }.property('@each.isCompleted'),
 
-  allAreDone: function(key, value) {
-    if (value === undefined) {
+  allAreDone: Ember.computed('@each.isCompleted', {
+    get: function() {
       return !!this.get('length') && this.everyProperty('isCompleted', true);
-    } else {
+    },
+    set: function(key, value) {
       this.setEach('isCompleted', value);
       this.invoke('save');
       return value;
     }
-  }.property('@each.isCompleted')
+  })
 
 });

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "todomvc-ember-cli",
   "dependencies": {
-    "ember": "1.11.3",
+    "ember": "1.12.1",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "0.1.3",
     "ember-data": "1.0.0-beta.16.1",

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "ember": "1.12.1",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "0.1.3",
-    "ember-data": "1.0.0-beta.16.1",
+    "ember-data": "1.0.0-beta.17",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
     "ember-localstorage-adapter": "0.5.3",
     "ember-qunit": "0.3.1",


### PR DESCRIPTION
Upgrade Ember after [v.1.12 being released](http://emberjs.com/blog/2015/05/13/ember-1-12-released.html).

Fixes #10.
- [x] Upgrade Ember
- [x] Fix deprecations according to [transition plan](http://emberjs.com/deprecations/v1.x/#toc_deprecations-added-in-1-12):
  - [x] [Computed properties with a shared getter and setter](http://emberjs.com/deprecations/v1.x/#toc_computed-properties-with-a-shared-getter-and-setter)
- [x] Upgrade Ember Data (see [SO#29357166](http://stackoverflow.com/questions/29357166/deprecation-warning-on-ember-data-models)).
